### PR TITLE
create python script to retrieve every pages of a bookstack and save it to a folder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+BOOKSTACK_TOKEN_ID=votre_token_bookstack
+BOOKSTACK_TOKEN_SECRET=votre_secret_token
+BOOKSTACK_URL=http://localhost:6875

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+exports/*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # Chatbot
-Chatbot IA
+
+## Export BookStack pages to PDF
+
+### Prerequisites
+- Python 3.9+
+- BookStack API token (token id + token secret)
+- BookStack URL
+
+### Setup
+1. Create a virtual environment
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+2. Install dependencies
+```bash
+pip install -r requirements.txt
+```
+
+3. Create a `.env` file (or update it) at the project root:
+```env
+BOOKSTACK_URL=your_bookstack_url
+BOOKSTACK_TOKEN_ID=your_token_id
+BOOKSTACK_TOKEN_SECRET=your_token_secret
+```
+
+### Run the export
+```bash
+python export_pages.py
+```
+
+PDFs will be saved to `exports/`

--- a/bookstack_client.py
+++ b/bookstack_client.py
@@ -1,0 +1,41 @@
+import json
+import urllib.error
+import urllib.request
+
+
+class BookStackClient:
+    def __init__(self, base_url, token_id, token_secret):
+        self.base_url = base_url.rstrip("/")
+        self.headers = {"Authorization": f"Token {token_id}:{token_secret}"}
+
+    def _get(self, url):
+        req = urllib.request.Request(url, headers=self.headers, method="GET")
+        try:
+            with urllib.request.urlopen(req) as resp:
+                return resp.status, resp.read()
+        except urllib.error.HTTPError as e:
+            return e.code, e.read()
+
+    def build_url(self, path_or_url):
+        return f"{self.base_url}{path_or_url}"
+        
+
+    def list_pages(self, url=None):
+        path = "/api/pages"
+        url = self.build_url(path)
+        status, body = self._get(url)
+        if status >= 400:
+            raise RuntimeError(
+                f"HTTP {status} for {url}: {body.decode('utf-8', errors='replace')}"
+            )
+        return json.loads(body.decode("utf-8"))
+
+    def export_page_pdf(self, page_id):
+        path = f"/api/pages/{page_id}/export/pdf"
+        url = self.build_url(path)
+        status, body = self._get(url)
+        if status >= 400:
+            raise RuntimeError(
+                f"HTTP {status} for {url}: {body.decode('utf-8', errors='replace')}"
+            )
+        return body

--- a/export_pages.py
+++ b/export_pages.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import os
+import sys
+from dotenv import load_dotenv
+from bookstack_client import BookStackClient
+
+
+
+def main():
+    load_dotenv(".env")
+    out_dir = 'exports'
+    token_id = os.getenv("BOOKSTACK_TOKEN_ID")
+    token_secret = os.getenv("BOOKSTACK_TOKEN_SECRET")
+    base_url = os.getenv("BOOKSTACK_URL")
+    if not token_id or not token_secret or not base_url:
+        print("Missing BOOKSTACK_TOKEN_ID or BOOKSTACK_TOKEN_SECRET or BOOKSTACK_URL", file=sys.stderr)
+        return 1
+
+    
+    client = BookStackClient(base_url, token_id, token_secret)
+
+    os.makedirs(out_dir, exist_ok=True)
+    try:
+        payload = client.list_pages()
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+
+    for item in payload.get("data", []):
+        page_id = item.get("id")
+        if page_id is None:
+            continue
+        try:
+            pdf = client.export_page_pdf(page_id)
+        except RuntimeError as e:
+            print(str(e), file=sys.stderr)
+            continue
+        out_file = os.path.join(out_dir, f"page-{page_id}.pdf")
+        with open(out_file, "wb") as f:
+            f.write(pdf)
+        print(f"Saved {out_file}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-dotenv>=1.0.0


### PR DESCRIPTION
- Introduced a reusable BookStack API client bookstack_client.py per-endpoint methods (list pages, export page PDF).
- Update Documentation for the requirement in order to be able to run the script
- Added a Python-based exporter export_pages.py to download all BookStack pages as PDFs, with pagination support and configurable output directory.